### PR TITLE
Fix na_skip for NULL, fixes test case warning for path_islink

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -21,6 +21,10 @@ na_screen <- function(x, screen) {
 ## This needs generalising to different output types (matrix/vector)
 ## and input types (character, other).
 na_skip <- function(x, f, ...) {
+
+  ## NULL is special, cannot call is.na() on it, gives a warning
+  if (is.null(x)) return(f(x, ...))
+
   ok <- !is.na(x)
   if (all(ok)) {
     f(x)


### PR DESCRIPTION
Tell me if there is a better way. You cannot call is.na on NULL, because you get a warning. 
